### PR TITLE
Use timezone.now() instead of datetime.now() for timezone-aware datetime fields

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,10 @@ html version using the setup.py::
 Changelog:
 ==========
 
+0.17:
+------------------
+* support of timezone aware dates
+
 0.16:
 ------------------
 * Setup compatibility for Django 3.2 - Django 4.2.

--- a/authority/models.py
+++ b/authority/models.py
@@ -1,9 +1,9 @@
-from datetime import datetime
 from django.conf import settings
 from django.db import models
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.auth.models import Group
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from authority.managers import PermissionManager
@@ -50,7 +50,7 @@ class Permission(models.Model):
         ),
     )
 
-    date_requested = models.DateTimeField(_("date requested"), default=datetime.now)
+    date_requested = models.DateTimeField(_("date requested"), default=timezone.now)
     date_approved = models.DateTimeField(_("date approved"), blank=True, null=True)
 
     objects = PermissionManager()
@@ -71,7 +71,7 @@ class Permission(models.Model):
     def save(self, *args, **kwargs):
         # Make sure the approval date is always set
         if self.approved and not self.date_approved:
-            self.date_approved = datetime.now()
+            self.date_approved = timezone.now()
         super(Permission, self).save(*args, **kwargs)
 
     def approve(self, creator):

--- a/authority/tests.py
+++ b/authority/tests.py
@@ -4,8 +4,9 @@ from django.contrib.auth.models import Group, Permission as DjangoPermission
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import MultipleObjectsReturned
 from django.db.models import Q
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
+from django.utils import timezone
 
 import authority
 from authority import permissions
@@ -436,6 +437,60 @@ class GroupPermissionCacheTestCase(SmartCachingTestCase):
             "foo", self.group, approved=True,
         )
         self.assertTrue(can_foo_with_group)
+
+
+class TimezoneAwarenessTestCase(TestCase):
+    """
+    Tests that Permission date fields use timezone-aware datetimes
+    when USE_TZ=True and naive datetimes when USE_TZ=False.
+    """
+
+    fixtures = FIXTURES
+
+    def setUp(self):
+        self.user = User.objects.get(QUERY)
+
+    @override_settings(USE_TZ=True)
+    def test_date_requested_is_aware_when_use_tz_true(self):
+        perm = Permission.objects.create(
+            user=self.user,
+            content_object=self.user,
+            codename="user_permission.browse_user",
+        )
+        self.assertTrue(timezone.is_aware(perm.date_requested))
+
+    @override_settings(USE_TZ=False)
+    def test_date_requested_is_naive_when_use_tz_false(self):
+        perm = Permission.objects.create(
+            user=self.user,
+            content_object=self.user,
+            codename="user_permission.browse_user",
+        )
+        self.assertTrue(timezone.is_naive(perm.date_requested))
+
+    @override_settings(USE_TZ=True)
+    def test_date_approved_is_aware_when_use_tz_true(self):
+        perm = Permission(
+            user=self.user,
+            content_object=self.user,
+            codename="user_permission.browse_user",
+            approved=True,
+        )
+        perm.save()
+        self.assertIsNotNone(perm.date_approved)
+        self.assertTrue(timezone.is_aware(perm.date_approved))
+
+    @override_settings(USE_TZ=False)
+    def test_date_approved_is_naive_when_use_tz_false(self):
+        perm = Permission(
+            user=self.user,
+            content_object=self.user,
+            codename="user_permission.browse_user",
+            approved=True,
+        )
+        perm.save()
+        self.assertIsNotNone(perm.date_approved)
+        self.assertTrue(timezone.is_naive(perm.date_approved))
 
 
 class AddPermissionTestCase(TestCase):


### PR DESCRIPTION
*   date_requested = models.DateTimeField(default=datetime.now) — field default

*   self.date_approved = datetime.now() — set in save() when permission is approved

This produces naive datetime objects, triggering RuntimeWarning when USE_TZ=True


Fix: Replace from datetime import datetime / datetime.now with from django.utils import timezone / timezone.now.

Risk: Low. Backwards compatible — timezone.now() respects USE_TZ setting.
